### PR TITLE
Use new name in schema

### DIFF
--- a/debian/gnome-shell-extension-cosmic-workspaces.install
+++ b/debian/gnome-shell-extension-cosmic-workspaces.install
@@ -1,1 +1,1 @@
-schemas/org.gnome.shell.extensions.vertical-overview.gschema.xml usr/share/glib-2.0/schemas
+schemas/org.gnome.shell.extensions.cosmic-workspaces.gschema.xml usr/share/glib-2.0/schemas

--- a/prefs.js
+++ b/prefs.js
@@ -10,7 +10,7 @@ const BuilderScope = GObject.registerClass({
 }, class BuilderScope extends GObject.Object {
     _init() {
         super._init()
-        this.settings = Util.getSettings('org.gnome.shell.extensions.vertical-overview');
+        this.settings = Util.getSettings('org.gnome.shell.extensions.cosmic-workspaces');
     }
 
     vfunc_create_closure(builder, handlerName, flags, connectObject) {
@@ -50,7 +50,7 @@ function buildPrefsWidget() {
     builder.set_translation_domain('gettext-domain');
     builder.add_from_file(Self.dir.get_path() + '/settings.ui');
 
-    let settings = Util.getSettings('org.gnome.shell.extensions.vertical-overview');
+    let settings = Util.getSettings('org.gnome.shell.extensions.cosmic-workspaces');
     for (var key of settings.list_keys()) {
         let obj = builder.get_object(key);
         let value = settings.get_value(key);

--- a/schemas/org.gnome.shell.extensions.cosmic-workspaces.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.cosmic-workspaces.gschema.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist gettext-domain="gnome-shell-extensions">
-    <schema path="/org/gnome/shell/extensions/vertical-overview/" id="org.gnome.shell.extensions.vertical-overview">
+    <schema path="/org/gnome/shell/extensions/cosmic-workspaces/" id="org.gnome.shell.extensions.cosmic-workspaces">
         <!--The following two keys actually control the sizes of the thumbnails-->
         <key type="i" name="left-offset">
             <default>300</default>

--- a/util.js
+++ b/util.js
@@ -76,7 +76,7 @@ function bindSetting(label, callback, executeOnBind = true) {
     let settings = global.vertical_overview.settings;
     if (!settings) {
         settings = global.vertical_overview.settings = {
-            object: getSettings('org.gnome.shell.extensions.vertical-overview'),
+            object: getSettings('org.gnome.shell.extensions.cosmic-workspaces'),
             signals: {},
             callbacks: {}
         };


### PR DESCRIPTION
This extension was renamed from vertical-overview to cosmic-workspaces in 39ed0f4.  Update the schema filename, path, and id to match.