### PR TITLE
translate workspace container when dock and picker are on the same side

### DIFF
--- a/workspace.js
+++ b/workspace.js
@@ -13,6 +13,7 @@ var LAYOUT_SCALE_WEIGHT = 1;
 var LAYOUT_SPACE_WEIGHT = 0.1;
 const BACKGROUND_CORNER_RADIUS_PIXELS = 30;
 const BACKGROUND_MARGIN = 12;
+const { ExtensionState } = imports.misc.extensionUtils;
 
 const Workspace = imports.ui.workspace;
 const Self = imports.misc.extensionUtils.getCurrentExtension();
@@ -96,13 +97,34 @@ WorkspaceOverride = {
 
         const layoutManager = new Workspace.WorkspaceLayout(metaWorkspace, monitorIndex,
             overviewAdjustment);
-
+        
+        
         // Window previews
+
+        //if dock and workspace picker are on the same size translate by dock height
+        const cosmicDock = Main.extensionManager.lookup("cosmic-dock@system76.com");
+        translate_x = 0;
+        if (cosmicDock
+            && cosmicDock.stateObj.dockManager.mainDock.get_height() > cosmicDock.stateObj.dockManager.mainDock.get_y()) {
+
+            mainDock = cosmicDock.stateObj.dockManager.mainDock;
+            let dock_left = mainDock.get_x() <= 0
+            let picker_left = global.vertical_overview.workspace_picker_left;
+
+            if (dock_left && picker_left) {
+                translate_x = mainDock.get_width()
+            } else if (!dock_left && !picker_left) {
+                translate_x = -1 * mainDock.get_width()
+            }
+        }
+
         this._container = new Clutter.Actor({
             reactive: true,
             x_expand: true,
             y_expand: true,
+            translation_x: translate_x,
         });
+
         this._container.layout_manager = layoutManager;
         this.add_child(this._container);
 


### PR DESCRIPTION
Maybe closes #4 

## Before
![Screenshot from 2022-01-07 19-35-56](https://user-images.githubusercontent.com/58987761/148628759-4aed9863-b8a4-4b92-8e97-47f5ad0c2df5.png)

## After
![Screenshot from 2022-01-07 19-36-38](https://user-images.githubusercontent.com/58987761/148628767-069705ec-810c-4c0a-8fba-9fe057c1e877.png)

> Red is just to show the location of the workspace container. Actual PR is not red. This is visible without the red when two windows are open. Then one window will overlap the workspace picker.