### PR TITLE
Pop 21.10: Major R2 Auto Login Bug

### DIFF
--- a/overviewControls.js
+++ b/overviewControls.js
@@ -59,6 +59,25 @@ var ControlsManagerLayoutOverride = {
         const { spacing } = this;
         const { expandFraction } = this._workspacesThumbnails;
 
+        //if dock and workspace picker are on the same side translate by dock width
+        translate_x = spacing;
+        const cosmicDock = _Util.getDock();
+        if (cosmicDock) {
+            const mainDock = cosmicDock.stateObj.dockManager.mainDock
+            if (mainDock.get_height() > mainDock.get_y()) {
+                const dock_left = mainDock.get_x() <= 0
+                const picker_left = global.vertical_overview.workspace_picker_left;
+
+                if (dock_left && picker_left)  {
+                    translate_x += mainDock.get_width()
+                } else if (!dock_left && !picker_left) {
+                    translate_x -= (mainDock.get_width() + spacing)
+                } else if (dock_left && !picker_left) {
+                    translate_x = 0;
+                }
+            }
+        }
+
         switch (state) {
         case ControlsState.HIDDEN:
                 if (global.vertical_overview.misc_dTPLeftRightFix) {
@@ -74,7 +93,7 @@ var ControlsManagerLayoutOverride = {
         case ControlsState.WINDOW_PICKER:
         case ControlsState.APP_GRID:
             workspaceBox.set_origin(
-                leftOffset + spacing,
+                leftOffset + translate_x,
                 startY + searchHeight + spacing * expandFraction);
             workspaceBox.set_size(
                 width - leftOffset - rightOffset - (spacing * 2),
@@ -175,8 +194,8 @@ var ControlsManagerLayoutOverride = {
                 size = [rightOffset, height];
             }
 
-            const cosmicDock = Main.extensionManager.lookup("cosmic-dock@system76.com");
-            if (cosmicDock && cosmicDock.state === ExtensionState.ENABLED) {
+            const cosmicDock = _Util.getDock();
+            if (cosmicDock) {
                 const mainDock = cosmicDock.stateObj.dockManager.mainDock;
 
                 const [, dashHeight] = mainDock.get_preferred_height(width);

--- a/overviewControls.js
+++ b/overviewControls.js
@@ -64,10 +64,9 @@ var ControlsManagerLayoutOverride = {
         const cosmicDock = _Util.getDock();
         if (cosmicDock) {
             const mainDock = cosmicDock.stateObj.dockManager.mainDock
+            const picker_left = global.vertical_overview.workspace_picker_left;
             if (mainDock.get_height() > mainDock.get_y()) {
                 const dock_left = mainDock.get_x() <= 0
-                const picker_left = global.vertical_overview.workspace_picker_left;
-
                 if (dock_left && picker_left)  {
                     translate_x += mainDock.get_width()
                 } else if (!dock_left && !picker_left) {
@@ -75,6 +74,8 @@ var ControlsManagerLayoutOverride = {
                 } else if (dock_left && !picker_left) {
                     translate_x = 0;
                 }
+            } else if (!picker_left) {
+                translate_x = 0;
             }
         }
 

--- a/util.js
+++ b/util.js
@@ -1,3 +1,4 @@
+const Main = imports.ui.main;
 const Gi = imports._gi;
 const Gio = imports.gi.Gio;
 const GioSSS = Gio.SettingsSchemaSource;
@@ -58,6 +59,17 @@ function bindSetting(label, callback, executeOnBind = true) {
 
     if (executeOnBind) callback(settings.object, label);
     return signal;
+}
+
+// returns a cosmic dock object if safe to use else undefined
+function getDock() {
+    const cosmicDock = Main.extensionManager.lookup("cosmic-dock@system76.com");
+    if (cosmicDock
+        && cosmicDock.stateObj
+        && cosmicDock.stateObj.dockManager.mainDock
+        && cosmicDock.state === ExtensionUtils.ExtensionState.ENABLED) {
+        return cosmicDock;
+    }
 }
 
 function unbindSetting(label, callback) {

--- a/workspace.js
+++ b/workspace.js
@@ -99,30 +99,10 @@ WorkspaceOverride = {
             overviewAdjustment);
 
         // Window previews
-
-        //if dock and workspace picker are on the same size translate by dock height
-        const cosmicDock = Main.extensionManager.lookup("cosmic-dock@system76.com");
-        translate_x = 0;
-
-        if (cosmicDock && cosmicDock.stateObj) {
-            const mainDock = cosmicDock.stateObj.dockManager.mainDock
-            if (mainDock.get_height() > mainDock.get_y()) {
-                const dock_left = mainDock.get_x() <= 0
-                const picker_left = global.vertical_overview.workspace_picker_left;
-
-                if (dock_left && picker_left)  {
-                    translate_x = mainDock.get_width()
-                } else if (!dock_left && !picker_left) {
-                    translate_x = -1 * mainDock.get_width()
-                }
-            }
-        }
-
         this._container = new Clutter.Actor({
             reactive: true,
             x_expand: true,
             y_expand: true,
-            translation_x: translate_x,
         });
 
         this._container.layout_manager = layoutManager;

--- a/workspacesView.js
+++ b/workspacesView.js
@@ -140,8 +140,8 @@ var SecondaryMonitorDisplayOverride = {
                 size = [rightOffset, height];
             }
 
-            const cosmicDock = Main.extensionManager.lookup("cosmic-dock@system76.com");
-            if (cosmicDock && cosmicDock.state === ExtensionState.ENABLED) {
+            const cosmicDock = Util.getDock();
+            if (cosmicDock) {
                 const mainDock = cosmicDock.stateObj.dockManager.mainDock;
 
                 const [, dashHeight] = mainDock.get_preferred_height(width);


### PR DESCRIPTION
In a rare "race-like" condition that only occurs on some hardware, cosmic-dock can be loaded before the monitor is ready to display, thus cosmic-dock runs in a "headless" mode, and `mainDock` returns null. Because cosmic-workspaces is loaded after cosmic-dock, this causes the dock to be functional, but the rest of the UI to not be. 

This fixes assembly's `Pop 21.10: Major R2 Auto Login Bug with AMD GPUs, especially 6600xt` issue.