### PR TITLE
fix: multiple displays with different resolutions + make indicators vertical

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -9,6 +9,7 @@ const Util = Self.imports.util;
 const OverviewControlsOverride = Self.imports.overviewControls;
 const WorkspacesViewOverrides = Self.imports.workspacesView;
 const WorkspaceThumbnailOverrides = Self.imports.workspaceThumbnail;
+const WorkspaceSwitcherPopupOverride = Self.imports.workspaceSwitcherPopup;
 const DashOverride = Self.imports.dash;
 const Gestures = Self.imports.gestures;
 const Background = imports.ui.background;
@@ -40,6 +41,7 @@ function enable() {
     WorkspaceOverrides.override();
     Gestures.override();
     DashOverride.override();
+    WorkspaceSwitcherPopupOverride.override();
 
     //this is the magic function that switches the internal layout to vertical
     global.workspace_manager.override_workspace_layout(Meta.DisplayCorner.TOPLEFT, true, -1, 1);
@@ -60,6 +62,7 @@ function disable() {
     WorkspaceThumbnailOverrides.reset();
     Gestures.reset();
     DashOverride.reset(true);
+    WorkspaceSwitcherPopupOverride.reset();
 
     rebind_keys(Main.overview._overview._controls);
 

--- a/overviewControls.js
+++ b/overviewControls.js
@@ -60,6 +60,7 @@ var ControlsManagerLayoutOverride = {
 
         const { spacing } = this;
         const { expandFraction } = this._workspacesThumbnails;
+        const { scaleFactor } = St.ThemeContext.get_for_stage(global.stage);
 
         switch (state) {
         case ControlsState.HIDDEN:
@@ -75,7 +76,7 @@ var ControlsManagerLayoutOverride = {
             break;
         case ControlsState.WINDOW_PICKER:
         case ControlsState.APP_GRID:
-            const newWidth = width - this.leftOffset - this.rightOffset - (spacing * 2);
+            const newWidth = width - this._workspacesThumbnails.width * ( scaleFactor > 1 ? scaleFactor : 2);
             const newXOrigin = global.vertical_overview.workspace_picker_left
                 ? this._workspacesThumbnails.x + this._workspacesThumbnails.width + spacing * 2
                 : this._workspacesThumbnails.x - newWidth - spacing * 2;

--- a/overviewControls.js
+++ b/overviewControls.js
@@ -141,12 +141,8 @@ var ControlsManagerLayoutOverride = {
         let availableHeight = height;
 
         // Search entry
-        let [searchHeight] = this._searchEntry.get_preferred_height(width);
-        childBox.set_origin(leftOffset, startY);
-        childBox.set_size(width - leftOffset - rightOffset, searchHeight);
-        this._searchEntry.allocate(childBox);
-
-        availableHeight -= searchHeight + spacing;
+        const searchHeight = 0;
+        availableHeight -= spacing;
 
         // Dash
         if (global.vertical_overview.dash_override) {

--- a/overviewControls.js
+++ b/overviewControls.js
@@ -313,8 +313,6 @@ var ControlsManagerOverride = {
 
         this._searchController.prepareToEnterOverview();
         this._workspacesDisplay.prepareToEnterOverview();
-        if (!this._workspacesDisplay.activeWorkspaceHasMaximizedWindows())
-            Main.overview.fadeOutDesktop();
 
         this._stateAdjustment.value = ControlsState.HIDDEN;
 

--- a/overviewControls.js
+++ b/overviewControls.js
@@ -61,26 +61,6 @@ var ControlsManagerLayoutOverride = {
         const { spacing } = this;
         const { expandFraction } = this._workspacesThumbnails;
 
-        //if dock and workspace picker are on the same side translate by dock width
-        translate_x = spacing;
-        const cosmicDock = _Util.getDock();
-        if (cosmicDock) {
-            const mainDock = cosmicDock.stateObj.dockManager.mainDock
-            const picker_left = global.vertical_overview.workspace_picker_left;
-            if (mainDock.get_height() > mainDock.get_y()) {
-                const dock_left = mainDock.get_x() <= 0
-                if (dock_left && picker_left)  {
-                    translate_x += mainDock.get_width()
-                } else if (!dock_left && !picker_left) {
-                    translate_x -= (mainDock.get_width() + spacing)
-                } else if (dock_left && !picker_left) {
-                    translate_x = 0;
-                }
-            } else if (!picker_left) {
-                translate_x = 0;
-            }
-        }
-
         switch (state) {
         case ControlsState.HIDDEN:
                 if (global.vertical_overview.misc_dTPLeftRightFix) {
@@ -95,11 +75,15 @@ var ControlsManagerLayoutOverride = {
             break;
         case ControlsState.WINDOW_PICKER:
         case ControlsState.APP_GRID:
+            const newWidth = width - this.leftOffset - this.rightOffset - (spacing * 2);
+            const newXOrigin = global.vertical_overview.workspace_picker_left
+                ? this._workspacesThumbnails.x + this._workspacesThumbnails.width + spacing * 2
+                : this._workspacesThumbnails.x - newWidth - spacing * 2;
             workspaceBox.set_origin(
-                this.leftOffset + translate_x,
+                newXOrigin,
                 startY + searchHeight + spacing * expandFraction);
             workspaceBox.set_size(
-                width - this.leftOffset - this.rightOffset - (spacing * 2),
+                newWidth,
                 height - startY - (searchHeight + spacing * expandFraction) * 2);
             break;
         }

--- a/workspaceSwitcherPopup.js
+++ b/workspaceSwitcherPopup.js
@@ -18,6 +18,7 @@ function reset() {
 
 var WorkspaceSwitcherPopupOverride = {
     _redisplay: function() {
+        // Move OSD to the side of the screen coresponding to the workspace picker location
         this._list.set_vertical(true);
         if (global.vertical_overview.workspace_picker_left) {
             this.set_x_align(Clutter.ActorAlign.START);
@@ -26,8 +27,24 @@ var WorkspaceSwitcherPopupOverride = {
         }
         this.set_y_align(Clutter.ActorAlign.CENTER);
 
-        let workspaceManager = global.workspace_manager;
+        // translate x by dock width if picker and dock are on the same side
+        const cosmicDock = Util.getDock();
+        if (cosmicDock) {
+            const mainDock = cosmicDock.stateObj.dockManager.mainDock
+            const picker_left = global.vertical_overview.workspace_picker_left;
+            const dashWidth = mainDock.width;
 
+            if (mainDock.get_height() > mainDock.get_y()) {
+                const dock_left = mainDock.get_x() <= 0
+                if (dock_left && picker_left)  {
+                    this.set_translation(dashWidth,0,0);
+                } else if (!dock_left && !picker_left) {
+                    this.set_translation(-dashWidth,0,0);
+                }
+            }
+        }
+
+        let workspaceManager = global.workspace_manager;
         this._list.destroy_all_children();
 
         for (let i = 0; i < workspaceManager.n_workspaces; i++) {

--- a/workspaceSwitcherPopup.js
+++ b/workspaceSwitcherPopup.js
@@ -1,0 +1,45 @@
+const { Clutter, St } = imports.gi;
+
+const { ExtensionState } = imports.misc.extensionUtils;
+const OverviewControls = imports.ui.overviewControls;
+const WorkspaceSwitcherPopup = imports.ui.workspaceSwitcherPopup;
+const Main = imports.ui.main;
+
+const Self = imports.misc.extensionUtils.getCurrentExtension();
+const Util = Self.imports.util;
+
+function override() {
+    global.vertical_overview.GSFunctions['WorkspaceSwitcherPopup'] = Util.overrideProto(WorkspaceSwitcherPopup.WorkspaceSwitcherPopup.prototype, WorkspaceSwitcherPopupOverride);
+}
+
+function reset() {
+    Util.overrideProto(WorkspaceSwitcherPopup.WorkspaceSwitcherPopup.prototype, WorkspaceSwitcherPopupOverride);
+}
+
+var WorkspaceSwitcherPopupOverride = {
+    _redisplay: function() {
+        this._list.set_vertical(true);
+        if (global.vertical_overview.workspace_picker_left) {
+            this.set_x_align(Clutter.ActorAlign.START);
+        } else {
+            this.set_x_align(Clutter.ActorAlign.END);
+        }
+        this.set_y_align(Clutter.ActorAlign.CENTER);
+
+        let workspaceManager = global.workspace_manager;
+
+        this._list.destroy_all_children();
+
+        for (let i = 0; i < workspaceManager.n_workspaces; i++) {
+            const indicator = new St.Bin({
+                style_class: 'ws-switcher-indicator',
+            });
+
+            if (i === this._activeWorkspaceIndex)
+                indicator.add_style_pseudo_class('active');
+
+            this._list.add_actor(indicator);
+        }
+    }
+
+} 

--- a/workspaceSwitcherPopup.js
+++ b/workspaceSwitcherPopup.js
@@ -32,7 +32,7 @@ var WorkspaceSwitcherPopupOverride = {
         if (cosmicDock) {
             const mainDock = cosmicDock.stateObj.dockManager.mainDock
             const picker_left = global.vertical_overview.workspace_picker_left;
-            const dashWidth = mainDock.width;
+            const dashWidth = mainDock._slider.get_child().get_width();
 
             if (mainDock.get_height() > mainDock.get_y()) {
                 const dock_left = mainDock.get_x() <= 0

--- a/workspaceThumbnail.js
+++ b/workspaceThumbnail.js
@@ -159,7 +159,7 @@ var ThumbnailsBoxOverride = {
         const scale = Math.max(1, Main.layoutManager.getWorkAreaForMonitor(this._monitorIndex).width / Main.layoutManager.primaryMonitor.width);
         if (this._monitorIndex == Main.layoutManager.primaryIndex) {
             global.vertical_overview.workspacePickerX1 = box.x1;
-            global.vertical_overview.workspacePickerWidth = box.get_width();
+            global.vertical_overview.workspacePickerWidth = box.get_width() / scaleFactor;
             width = box.get_width();
         } else {
             box.x1 = global.vertical_overview.workspacePickerX1 * scaleFactor;

--- a/workspaceThumbnail.js
+++ b/workspaceThumbnail.js
@@ -149,23 +149,23 @@ var ThumbnailsBoxOverride = {
         //set top and bottom margin
         box.y1 += 16;
         box.y2 -= 32;
-        let parentBox = box;
 
         var width;
+        const { scaleFactor } = St.ThemeContext.get_for_stage(global.stage);
+        const scale = Math.max(1, Main.layoutManager.getWorkAreaForMonitor(this._monitorIndex).width / Main.layoutManager.primaryMonitor.width);
         if (this._monitorIndex == Main.layoutManager.primaryIndex) {
             global.vertical_overview.workspacePickerX1 = box.x1;
             global.vertical_overview.workspacePickerWidth = box.get_width();
             width = box.get_width();
         } else {
-            const { scaleFactor } = St.ThemeContext.get_for_stage(global.stage);
-            const scale = Math.max(1, Main.layoutManager.getWorkAreaForMonitor(this._monitorIndex).width / Main.layoutManager.primaryMonitor.width);
-            box.x1 = global.vertical_overview.workspacePickerX1 * scaleFactor
+            box.x1 = global.vertical_overview.workspacePickerX1 * scale * scaleFactor;
             width = global.vertical_overview.workspacePickerWidth * scale * scaleFactor;
         }
 
         if (this._thumbnails.length == 0) // not visible
             return;
 
+        let parentBox = box;
         const themeNode = this.get_theme_node();
         box = themeNode.get_content_box(parentBox);
 
@@ -173,7 +173,6 @@ var ThumbnailsBoxOverride = {
         const portholeHeight = this._porthole.height;
         const ratio = portholeHeight / portholeWidth;
 
-        var width = box.get_width();
         var height = Math.round(width * ratio);
 
         let vScale = width / portholeWidth;
@@ -208,6 +207,12 @@ var ThumbnailsBoxOverride = {
         spacing *= additionalScale;
         vScale *= additionalScale;
         hScale *= additionalScale;
+
+        if (!global.vertical_overview.workspace_picker_left) {
+            const gap = 16 * scaleFactor;
+            const total_spacing = spacing * 2;
+            parentBox.x1 = portholeWidth - width - gap - total_spacing;
+        }
 
         parentBox.set_size(width + spacing*2, parentBox.get_height())
         this.set_allocation(parentBox);

--- a/workspaceThumbnail.js
+++ b/workspaceThumbnail.js
@@ -146,6 +146,10 @@ var ThumbnailsBoxOverride = {
     },
 
     vfunc_allocate: function(box) {
+
+        if (this._thumbnails.length == 0) // not visible
+            return;
+
         //set top and bottom margin
         box.y1 += 16;
         box.y2 -= 32;
@@ -161,9 +165,6 @@ var ThumbnailsBoxOverride = {
             box.x1 = global.vertical_overview.workspacePickerX1 * scaleFactor;
             width = global.vertical_overview.workspacePickerWidth * scale * scaleFactor;
         }
-
-        if (this._thumbnails.length == 0) // not visible
-            return;
 
         let parentBox = box;
         const themeNode = this.get_theme_node();
@@ -209,9 +210,13 @@ var ThumbnailsBoxOverride = {
         hScale *= additionalScale;
 
         if (!global.vertical_overview.workspace_picker_left) {
-            const gap = 16 * scaleFactor;
             const total_spacing = spacing * 2;
-            parentBox.x1 = portholeWidth - width - gap - total_spacing;
+            if (this._monitorIndex == Main.layoutManager.primaryIndex) {
+                parentBox.x1 -= total_spacing;
+            } else {
+                const gap = 16 * scaleFactor;
+                parentBox.x1 = portholeWidth - width - gap - total_spacing;
+            }
         }
 
         parentBox.set_size(width + spacing*2, parentBox.get_height())

--- a/workspaceThumbnail.js
+++ b/workspaceThumbnail.js
@@ -158,12 +158,15 @@ var ThumbnailsBoxOverride = {
         const { scaleFactor } = St.ThemeContext.get_for_stage(global.stage);
         const scale = Math.max(1, Main.layoutManager.getWorkAreaForMonitor(this._monitorIndex).width / Main.layoutManager.primaryMonitor.width);
 
+        var mainDockHides;
         var mainDockWidth;
         var mainDockPosition;
         const cosmicDock = Util.getDock();
         if (cosmicDock) {
             global.log("monitor test");
             const mainDock = cosmicDock.stateObj.dockManager.mainDock;
+            const dockSettings = cosmicDock.stateObj.dockManager.settings;
+            mainDockHides = dockSettings.intellihideMode || dockSettings.dockFixed || !dockSettings.multiMonitor
             mainDockPosition = mainDock.position;
             [, mainDockWidth] = mainDock.get_preferred_width(height);
         }
@@ -176,7 +179,7 @@ var ThumbnailsBoxOverride = {
             box.x1 = global.vertical_overview.workspacePickerX1 * scaleFactor;
             width = global.vertical_overview.workspacePickerWidth * scale * scaleFactor;
 
-            if (mainDockPosition == St.Side.LEFT) {
+            if (mainDockPosition == St.Side.LEFT && mainDockHides) {
                 box.x1 -= mainDockWidth;
             }
         }
@@ -231,6 +234,9 @@ var ThumbnailsBoxOverride = {
             } else {
                 const gap = 16 * scaleFactor;
                 parentBox.x1 = portholeWidth - width - gap - total_spacing;
+                if (mainDockPosition == St.Side.RIGHT && !mainDockHides) {
+                    parentBox.x1 -= mainDockWidth;
+                }
             }
         }
 

--- a/workspaceThumbnail.js
+++ b/workspaceThumbnail.js
@@ -160,15 +160,16 @@ var ThumbnailsBoxOverride = {
 
         var mainDockHides;
         var mainDockWidth;
+        var mainDockHeight;
         var mainDockPosition;
         const cosmicDock = Util.getDock();
         if (cosmicDock) {
-            global.log("monitor test");
             const mainDock = cosmicDock.stateObj.dockManager.mainDock;
             const dockSettings = cosmicDock.stateObj.dockManager.settings;
-            mainDockHides = dockSettings.intellihideMode || dockSettings.dockFixed || !dockSettings.multiMonitor
+            mainDockHides = dockSettings.intellihideMode || dockSettings.dockFixed || !dockSettings.multiMonitor;
             mainDockPosition = mainDock.position;
             [, mainDockWidth] = mainDock.get_preferred_width(height);
+            [, mainDockHeight] = mainDock.get_preferred_height(width);
         }
 
         if (this._monitorIndex == Main.layoutManager.primaryIndex) {
@@ -181,6 +182,9 @@ var ThumbnailsBoxOverride = {
 
             if (mainDockPosition == St.Side.LEFT && mainDockHides) {
                 box.x1 -= mainDockWidth;
+            } else if (mainDockPosition == St.Side.BOTTOM && !mainDockHides) {
+                global.log("box height = " + mainDockHeight);
+                box.set_size(box.get_width(), box.get_height() - mainDockHeight);
             }
         }
 

--- a/workspaceThumbnail.js
+++ b/workspaceThumbnail.js
@@ -157,6 +157,17 @@ var ThumbnailsBoxOverride = {
         var width;
         const { scaleFactor } = St.ThemeContext.get_for_stage(global.stage);
         const scale = Math.max(1, Main.layoutManager.getWorkAreaForMonitor(this._monitorIndex).width / Main.layoutManager.primaryMonitor.width);
+
+        var mainDockWidth;
+        var mainDockPosition;
+        const cosmicDock = Util.getDock();
+        if (cosmicDock) {
+            global.log("monitor test");
+            const mainDock = cosmicDock.stateObj.dockManager.mainDock;
+            mainDockPosition = mainDock.position;
+            [, mainDockWidth] = mainDock.get_preferred_width(height);
+        }
+
         if (this._monitorIndex == Main.layoutManager.primaryIndex) {
             global.vertical_overview.workspacePickerX1 = box.x1;
             global.vertical_overview.workspacePickerWidth = box.get_width() / scaleFactor;
@@ -164,6 +175,10 @@ var ThumbnailsBoxOverride = {
         } else {
             box.x1 = global.vertical_overview.workspacePickerX1 * scaleFactor;
             width = global.vertical_overview.workspacePickerWidth * scale * scaleFactor;
+
+            if (mainDockPosition == St.Side.LEFT) {
+                box.x1 -= mainDockWidth;
+            }
         }
 
         let parentBox = box;

--- a/workspaceThumbnail.js
+++ b/workspaceThumbnail.js
@@ -177,7 +177,7 @@ var ThumbnailsBoxOverride = {
             global.vertical_overview.workspacePickerWidth = box.get_width() / scaleFactor;
             width = box.get_width();
         } else {
-            box.x1 = global.vertical_overview.workspacePickerX1 * scaleFactor;
+            box.x1 = global.vertical_overview.workspacePickerX1;
             width = global.vertical_overview.workspacePickerWidth * scale * scaleFactor;
 
             if (mainDockPosition == St.Side.LEFT && mainDockHides) {

--- a/workspaceThumbnail.js
+++ b/workspaceThumbnail.js
@@ -151,6 +151,18 @@ var ThumbnailsBoxOverride = {
         box.y2 -= 32;
         let parentBox = box;
 
+        var width;
+        if (this._monitorIndex == Main.layoutManager.primaryIndex) {
+            global.vertical_overview.workspacePickerX1 = box.x1;
+            global.vertical_overview.workspacePickerWidth = box.get_width();
+            width = box.get_width();
+        } else {
+            const { scaleFactor } = St.ThemeContext.get_for_stage(global.stage);
+            const scale = Math.max(1, Main.layoutManager.getWorkAreaForMonitor(this._monitorIndex).width / Main.layoutManager.primaryMonitor.width);
+            box.x1 = global.vertical_overview.workspacePickerX1 * scaleFactor
+            width = global.vertical_overview.workspacePickerWidth * scale * scaleFactor;
+        }
+
         if (this._thumbnails.length == 0) // not visible
             return;
 
@@ -193,15 +205,12 @@ var ThumbnailsBoxOverride = {
         let additionalScale = (box.get_height() < totalHeight) ?  box.get_height() / totalHeight : 1;
         height *= additionalScale;
         width *= additionalScale;
-        parentBox.set_size(width + spacing*2, parentBox.get_height())
         spacing *= additionalScale;
         vScale *= additionalScale;
         hScale *= additionalScale;
+
+        parentBox.set_size(width + spacing*2, parentBox.get_height())
         this.set_allocation(parentBox);
-        
-        if (this._monitorIndex == Main.layoutManager.primaryIndex) {
-            global.vertical_overview.primaryThumbnailWidth = width - spacing;
-        }
 
         box.x2 = box.x1 + width;
 
@@ -226,7 +235,7 @@ var ThumbnailsBoxOverride = {
                 y1 += placeholderHeight + spacing;
             }
 
-            childBox.set_origin(box.x1 + (box.get_width() - width)/2, y1);
+            childBox.set_origin(spacing, y1);
             childBox.set_size(width, height);
             thumbnail.setScale(vScale, hScale);
             thumbnail.allocate(childBox);
@@ -247,8 +256,8 @@ var ThumbnailsBoxOverride = {
         let indicatorLeftFullBorder = indicatorThemeNode.get_padding(St.Side.LEFT) + indicatorThemeNode.get_border_width(St.Side.LEFT);
         let indicatorRightFullBorder = indicatorThemeNode.get_padding(St.Side.RIGHT) + indicatorThemeNode.get_border_width(St.Side.RIGHT);
 
-        childBox.x1 = box.x1 + (box.get_width() - width)/2;
-        childBox.x2 = box.x1 + (box.get_width() + width)/2;
+        childBox.x1 = spacing;
+        childBox.x2 = spacing + (box.get_width() + width)/2;
 
         const indicatorY1 = indicatorLowerY1 +
             (indicatorUpperY1 - indicatorLowerY1) * (indicatorValue % 1);

--- a/workspaceThumbnail.js
+++ b/workspaceThumbnail.js
@@ -158,7 +158,7 @@ var ThumbnailsBoxOverride = {
             global.vertical_overview.workspacePickerWidth = box.get_width();
             width = box.get_width();
         } else {
-            box.x1 = global.vertical_overview.workspacePickerX1 * scale * scaleFactor;
+            box.x1 = global.vertical_overview.workspacePickerX1 * scaleFactor;
             width = global.vertical_overview.workspacePickerWidth * scale * scaleFactor;
         }
 

--- a/workspacesView.js
+++ b/workspacesView.js
@@ -124,13 +124,12 @@ var SecondaryMonitorDisplayOverride = {
             Math.round((1 - SECONDARY_WORKSPACE_SCALE) * height / 2);
 
         const { scaleFactor } = St.ThemeContext.get_for_stage(global.stage);
-        const scale = (Main.layoutManager.getWorkAreaForMonitor(this._monitorIndex).width / Main.layoutManager.primaryMonitor.width);
+        const scale = Math.max(1, Main.layoutManager.getWorkAreaForMonitor(this._monitorIndex).width / Main.layoutManager.primaryMonitor.width);
         const adjust = scale * scaleFactor;
         const layoutManager = Main.overview._overview._controls.layoutManager;
-        const primaryThumbnailWidth = global.vertical_overview.primaryThumbnailWidth * adjust;
 
-        const leftOffset = scale == 1 ? layoutManager.leftOffset * adjust : primaryThumbnailWidth;
-        const rightOffset = scale == 1 ? layoutManager.rightOffset * adjust : primaryThumbnailWidth;
+        const leftOffset = layoutManager.leftOffset * scale * scaleFactor;
+        const rightOffset = layoutManager.rightOffset * scale * scaleFactor;
 
         // Workspace Thumbnails
         if (this._thumbnails.visible) {

--- a/workspacesView.js
+++ b/workspacesView.js
@@ -96,15 +96,21 @@ var SecondaryMonitorDisplayOverride = {
         const { ControlsState } = OverviewControls;
         const workspaceBox = box.copy();
         const [width, height] = workspaceBox.get_size();
+        const { scaleFactor } = St.ThemeContext.get_for_stage(global.stage);
+
+        const newWidth = width - this._thumbnails.width * ( scaleFactor > 1 ? scaleFactor : 2);
+        const newXOrigin = global.vertical_overview.workspace_picker_left
+              ? this._thumbnails.x + this._thumbnails.width + spacing * 2
+              : this._thumbnails.x - newWidth - spacing * 2;
 
         switch (state) {
             case ControlsState.HIDDEN:
                 break;
             case ControlsState.WINDOW_PICKER:
             case ControlsState.APP_GRID:
-                workspaceBox.set_origin(leftOffset, padding + spacing);
+                workspaceBox.set_origin(newXOrigin, padding + spacing);
                 workspaceBox.set_size(
-                    width - rightOffset - leftOffset,
+                    newWidth,
                     height - 2 * padding - spacing);
                 break;
         }

--- a/workspacesView.js
+++ b/workspacesView.js
@@ -125,7 +125,6 @@ var SecondaryMonitorDisplayOverride = {
 
         const { scaleFactor } = St.ThemeContext.get_for_stage(global.stage);
         const scale = Math.max(1, Main.layoutManager.getWorkAreaForMonitor(this._monitorIndex).width / Main.layoutManager.primaryMonitor.width);
-        const adjust = scale * scaleFactor;
         const layoutManager = Main.overview._overview._controls.layoutManager;
 
         const leftOffset = layoutManager.leftOffset * scale * scaleFactor;

--- a/workspacesView.js
+++ b/workspacesView.js
@@ -148,22 +148,6 @@ var SecondaryMonitorDisplayOverride = {
                 size = [rightOffset, height];
             }
 
-            const cosmicDock = Util.getDock();
-            if (cosmicDock) {
-                const mainDock = cosmicDock.stateObj.dockManager.mainDock;
-
-                const [, dashHeight] = mainDock.get_preferred_height(width);
-                const [, dashWidth] = mainDock.get_preferred_width(height);
-
-                if (mainDock.position == St.Side.BOTTOM) {
-                    size[1] -= dashHeight;
-                } else if (mainDock.position == St.Side.LEFT && global.vertical_overview.workspace_picker_left) {
-                    origin[0] += dashWidth;
-                } else if (mainDock.position == St.Side.RIGHT && !global.vertical_overview.workspace_picker_left) {
-                    origin[0] -= dashWidth;
-                }
-            }
-
             childBox.set_origin(...origin);
             childBox.set_size(...size);
 


### PR DESCRIPTION
- [x] Fix workspace picker scaling on multiple displays with different resolutions
- [x] Fix workspace indicators when using hotkeys to be vertical
![dots](https://user-images.githubusercontent.com/58987761/160686990-8525e844-d402-4b88-bfe3-8bd959f440cc.png)
 
 Requires pop-os/cosmic-dock#132