### PR TITLE
Remove unnecessary logging

### DIFF
--- a/workspacesView.js
+++ b/workspacesView.js
@@ -16,7 +16,9 @@ const Util = Self.imports.util;
 
 function override() {
     global.vertical_overview.GSFunctions['WorkspacesView'] = Util.overrideProto(WorkspacesView.WorkspacesView.prototype, WorkspacesViewOverride);
-    log('You may see an error below,\nSecondaryMonitorDisplay is defined as const for some reason.\nSecondaryMonitorDisplay = ' + WorkspacesView.SecondaryMonitorDisplay + '\nSince I\'m overriding values in that const an error show might show up.\n Feel free to ignore it');
+    log('You may see an error below,\nSecondaryMonitorDisplay is defined as const for some reason\nSince I\'m overriding values in that const, thus an error might show up.\n Feel free to ignore it');
+    SecondaryMonitorDisplay = WorkspacesView.SecondaryMonitorDisplay;
+
     global.vertical_overview.GSFunctions['SecondaryMonitorDisplay'] = Util.overrideProto(WorkspacesView.SecondaryMonitorDisplay.prototype, SecondaryMonitorDisplayOverride);
     log('Thank you, please carry on');
 


### PR DESCRIPTION
Load JS object in a way that doesn't result in workspace code
being printed to the system journal.

Fixes https://github.com/home-sweet-gnome/dash-to-panel/issues/1645#issuecomment-1112930912