### PR TITLE
fix(workspacesView): workaround for undefined `_workspaces`

### DIFF
--- a/workspaceThumbnail.js
+++ b/workspaceThumbnail.js
@@ -261,7 +261,7 @@ var ThumbnailsBoxOverride = {
                 this._dropPlaceholder.allocate(childBox);
 
                 Meta.later_add(Meta.LaterType.BEFORE_REDRAW, () => {
-                    this._dropPlaceholder.show();
+                    if (this._dropPlaceholder) this._dropPlaceholder.show()
                 });
             }
 

--- a/workspaceThumbnail.js
+++ b/workspaceThumbnail.js
@@ -216,7 +216,7 @@ var ThumbnailsBoxOverride = {
                 ...this._dropPlaceholder.get_position());
 
             Meta.later_add(Meta.LaterType.BEFORE_REDRAW, () => {
-                this._dropPlaceholder.hide();
+                if (this._dropPlaceholder) this._dropPlaceholder.hide()
             });
         }
 

--- a/workspacesView.js
+++ b/workspacesView.js
@@ -54,10 +54,14 @@ var WorkspacesViewOverride = {
     _getSpacing(box, fitMode, vertical) {
         const [width, height] = box.get_size();
         const [workspace] = this._workspaces;
-        var [, workspaceHeight] = workspace.get_preferred_height(width);
-        if (workspaceHeight > height) {
-            workspaceHeight = height;
+
+        var workspaceHeight = 0
+
+        if (undefined !== workspace) {
+            var [, preferredHeight] = workspace.get_preferred_height(width);
+            workspaceHeight = (preferredHeight > height) ? height : preferredHeight
         }
+
         let total_height = global.screen_height;
         let availableSpace = ((total_height - workspaceHeight) / 2) - (global.vertical_overview.workspacePeek || 0);
         const spacing = (availableSpace) * (1 - fitMode);
@@ -77,9 +81,11 @@ var WorkspacesViewOverride = {
 
         // Single fit mode implies centered too
         let [x1, y1] = box.get_origin();
-        var [, workspaceHeight] = workspace.get_preferred_height(width);
-        if (workspaceHeight > height) {
-            workspaceHeight = height;
+
+        var workspaceHeight = 0
+        if (undefined !== workspace) {
+            var [, preferredHeight] = workspace.get_preferred_height(width);
+            workspaceHeight = (preferredHeight > height) ? height : preferredHeight
         }
 
         y1 += (height - workspaceHeight) / 2;


### PR DESCRIPTION
Related to https://github.com/pop-os/pop/issues/2893

There seems to be a possible scenario where the workspace overview code is run at a time when the `_workspaces` property lacks any values, or perhaps is undefined itself. Whether it's caused by an extension or something else, we can add a check for `undefined`-ness and use a height of `0` by default if no workspace is found.

It would be ideal if @magicalraccoon could test this possible fix.