### PR TITLE
fix(workspaceBox) show thumbs when dual screens

### DIFF
--- a/workspacesView.js
+++ b/workspacesView.js
@@ -101,9 +101,7 @@ var SecondaryMonitorDisplayOverride = {
         const { scaleFactor } = St.ThemeContext.get_for_stage(global.stage);
 
         const newWidth = width - this._thumbnails.width * ( scaleFactor > 1 ? scaleFactor : 2);
-        const newXOrigin = global.vertical_overview.workspace_picker_left
-              ? this._thumbnails.x + this._thumbnails.width + spacing * 2
-              : this._thumbnails.x - newWidth - spacing * 2;
+        const newXOrigin = this._thumbnails.x + this._thumbnails.width + spacing * 2;
 
         switch (state) {
             case ControlsState.HIDDEN:


### PR DESCRIPTION
Hello!

This is my proposal to fix the following bug:
- When we use two screens and set "Placement of the Workspace Picker" as "Along the **right** side", the second screen, when we open the workspace view, does not show any window.
- Using  "Placement of the Workspace Picker" as "Along the **left** side", it works correctly.

## Before
![Screenshot from 2024-05-22 11-16-49](https://github.com/pop-os/cosmic-workspaces/assets/11338999/532269c8-63ee-4861-b782-83fb9869c922)

## After
![Screenshot from 2024-05-22 11-13-08](https://github.com/pop-os/cosmic-workspaces/assets/11338999/48788837-dd7f-4c5b-935d-45ece3a09faa)

Should fix:
- ~~https://github.com/pop-os/cosmic-workspaces/issues/87~~
- https://github.com/pop-os/gnome-shell/issues/102
- https://github.com/pop-os/pop/issues/2528
